### PR TITLE
inside clashes with ScalaTest

### DIFF
--- a/src/main/scala/scalac/localImports.scala
+++ b/src/main/scala/scalac/localImports.scala
@@ -24,8 +24,8 @@ class AddValsAndImport(plugin: Plugin, val global: Global) extends PluginCompone
   val phaseName =
     "local-imports"
 
-  val insideName =
-    TermName("inside")
+  val ⊢ : String =
+    "$u22A2"
 
   final
   def newTransformer(unit: CompilationUnit): Transformer =
@@ -35,16 +35,9 @@ class AddValsAndImport(plugin: Plugin, val global: Global) extends PluginCompone
       def transform(tree: Tree): Tree =
         tree match {
 
-          // allow infix usage
-          case Apply(Apply(Ident(insideName), valsValues), blocks) =>
+          case Apply(Select(valValue, TermName(⊢)), blocks) =>
             blocks.headOption
-              .fold(super.transform(tree)){
-                block => super.transform(addValsAndImportTo(valsValues, block))
-              }
-
-          case Apply(Select(valValue, TermName("$u22A2")), blocks) =>
-            blocks.headOption
-              .fold(super.transform(tree)){
+              .fold(super.transform(tree)) {
                 block => super.transform(addValsAndImportTo(List(valValue), block))
               }
 

--- a/src/main/scala/scalac/localImports.scala
+++ b/src/main/scala/scalac/localImports.scala
@@ -23,6 +23,7 @@ class AddValsAndImport(plugin: Plugin, val global: Global) extends PluginCompone
     "parser" :: Nil
   val phaseName =
     "local-imports"
+
   val insideName =
     TermName("inside")
 
@@ -34,10 +35,17 @@ class AddValsAndImport(plugin: Plugin, val global: Global) extends PluginCompone
       def transform(tree: Tree): Tree =
         tree match {
 
+          // allow infix usage
           case Apply(Apply(Ident(insideName), valsValues), blocks) =>
             blocks.headOption
               .fold(super.transform(tree)){
                 block => super.transform(addValsAndImportTo(valsValues, block))
+              }
+
+          case Apply(Select(valValue, TermName("$u22A2")), blocks) =>
+            blocks.headOption
+              .fold(super.transform(tree)){
+                block => super.transform(addValsAndImportTo(List(valValue), block))
               }
 
           case other =>

--- a/src/test/scala/scalac/LocalImplicitsTest.scala
+++ b/src/test/scala/scalac/LocalImplicitsTest.scala
@@ -32,7 +32,7 @@ object context {
 
 class LocalImports extends WordSpec with Matchers {
 
-  "inside" should {
+  "⊢" should {
 
     "be usable infix as 'x ⊢ y'" in {
 
@@ -58,20 +58,12 @@ class LocalImports extends WordSpec with Matchers {
     "be able to use object type members and vals" in {
 
       val result =
-        inside(T1) { x }
+        T1 ⊢ { x }
 
       val u1 = result shouldBe "hola"
 
       val result2 =
-        inside(T2) { x }
-
-      val u2 = result2 shouldBe 2
-    }
-
-    "shadow members of first arg if second arg has them" in {
-
-      val result2 =
-        inside(T1, T2) { x }
+        T2 ⊢ { x }
 
       val u2 = result2 shouldBe 2
     }
@@ -79,7 +71,7 @@ class LocalImports extends WordSpec with Matchers {
     "be able to use new _" in {
 
       val res =
-        inside(new U("hola")) { print }
+        new U("hola") ⊢ { print }
 
       res shouldBe "listen: hola"
     }
@@ -87,7 +79,7 @@ class LocalImports extends WordSpec with Matchers {
     "not support overriding an implicit declared in the same scope as the expression" in {
         """
         implicit val x0 = 1
-        inside(HasImplicitInt) { implicitly[Int] }
+        HasImplicitInt ⊢ { implicitly[Int] }
         """ shouldNot compile
       }
   }

--- a/src/test/scala/scalac/LocalImplicitsTest.scala
+++ b/src/test/scala/scalac/LocalImplicitsTest.scala
@@ -34,6 +34,27 @@ class LocalImports extends WordSpec with Matchers {
 
   "inside" should {
 
+    "be usable infix as 'x ⊢ y'" in {
+
+      val result =
+        T1 ⊢ { x }
+
+      val u1 = result shouldBe "hola"
+    }
+
+    "support nested usage" in {
+
+      val result =
+        T1 ⊢ {
+          val u = x
+          T2 ⊢ {
+            s"${u} ${x.toString}"
+          }
+        }
+
+      val u1 = result shouldBe "hola 2"
+    }
+
     "be able to use object type members and vals" in {
 
       val result =


### PR DESCRIPTION
See [here](https://github.com/scalatest/scalatest/blob/d40d278f2bb8e73431b942d87881fb6dbab75cb9/scalatest/src/main/scala/org/scalatest/Inside.scala#L103). We can

- [ ] document it, stop using TestSuite or anything extending Inside
- [ ] document it, stop using ScalaTest altogether (ScalaCheck? LambdaTest? Specs2?)
- [x] rename our `inside` extension

Alternative names:

``` scala
// this is *also* part of ScalaTest
in(x) { ... }
// can't help it
x ⊢ { ... }
```