### PR TITLE
rename to contexts

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 
-name          := "local-imports"
+name          := "contexts"
 organization  := "ohnosequences"
-description   := "A compiler plugin providing syntax for local imports"
+description   := "A Scala compiler plugin providing syntax for contexts `x ⊢ { ... }`"
 bucketSuffix  := "era7.com"
 scalaVersion  := "2.12.3"
 

--- a/src/main/resources/scalac-plugin.xml
+++ b/src/main/resources/scalac-plugin.xml
@@ -1,4 +1,4 @@
 <plugin>
   <name>local-imports</name>
-  <classname>ohnosequences.scalac.LocalImportsPlugin</classname>
+  <classname>ohnosequences.scalac.ContextsPlugin</classname>
 </plugin>

--- a/src/main/scala/scalac/contexts.scala
+++ b/src/main/scala/scalac/contexts.scala
@@ -8,9 +8,9 @@ import nsc.symtab.Flags._
 import nsc.ast.TreeDSL
 
 final
-class LocalImportsPlugin(val global: Global) extends Plugin {
-  val name        = "local-import"
-  val description = "Provides syntax for automatic local val and import"
+class ContextsPlugin(val global: Global) extends Plugin {
+  val name        = "contexts"
+  val description = "Provides syntax for contexts `x ⊢ { ... }`"
   val components  = new AddValsAndImport(this, global) :: Nil
 }
 

--- a/src/test/scala/scalac/contextsTest.scala
+++ b/src/test/scala/scalac/contextsTest.scala
@@ -30,7 +30,7 @@ object context {
   }
 }
 
-class LocalImports extends WordSpec with Matchers {
+class Contexts extends WordSpec with Matchers {
 
   "⊢" should {
 


### PR DESCRIPTION
I think it's a better name, even more so if we adopt the syntax proposed in #2. 